### PR TITLE
Mirror of salesforce argus#744

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/Notification.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/Notification.java
@@ -246,7 +246,7 @@ public class Notification extends JPAEntity implements Serializable {
         name = "NOTIFICATION_TRIGGER", joinColumns = @JoinColumn(name = "TRIGGER_ID"), inverseJoinColumns = @JoinColumn(name = "NOTIFICATION_ID")
     )
     List<Trigger> triggers = new ArrayList<>(0);
-    
+
 	boolean isSRActionable = false;
     
 	int severityLevel = 5;
@@ -481,7 +481,11 @@ public class Notification extends JPAEntity implements Serializable {
 		return cooldownExpirationByTriggerAndMetric;
 	}
 
-    /**
+    public void setCooldownExpirationMap(Map<String, Long> cooldownExpirationByTriggerAndMetric) {
+		this.cooldownExpirationByTriggerAndMetric = cooldownExpirationByTriggerAndMetric;
+	}
+
+	/**
      * Returns all metrics to be annotated.
      *
      * @return  list of metrics
@@ -613,6 +617,10 @@ public class Notification extends JPAEntity implements Serializable {
 
 	public Map<String, Boolean> getActiveStatusMap() {
 		return activeStatusByTriggerAndMetric;
+	}
+	
+	public void setActiveStatusMap(Map<String, Boolean> activeStatusByTriggerAndMetric) {
+		this.activeStatusByTriggerAndMetric = activeStatusByTriggerAndMetric;
 	}
 
     /**

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/DefaultAlertService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/DefaultAlertService.java
@@ -300,7 +300,7 @@ public class DefaultAlertService extends DefaultJPAService implements AlertServi
 		if(notificationsCache == null) {
 			synchronized(this) {
 				if(notificationsCache == null) {
-					notificationsCache = new NotificationsCache(_emProvider.get());
+					notificationsCache = new NotificationsCache(_emProvider);
 				}
 			}
 		}

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/NotificationsCache.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/NotificationsCache.java
@@ -6,6 +6,8 @@ import java.util.Map;
 
 import javax.persistence.EntityManager;
 
+import com.google.inject.Provider;
+
 public class NotificationsCache {
 	
 	private NotificationsCacheRefresherThread refresherThread;
@@ -16,7 +18,7 @@ public class NotificationsCache {
 
 	private boolean isNotificationsCacheRefreshed = false;
 	
-	public NotificationsCache(EntityManager em) {
+	public NotificationsCache(Provider<EntityManager> em) {
 		refresherThread = new NotificationsCacheRefresherThread(this, em);
 		refresherThread.setDaemon(true);
 		refresherThread.start();

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/NotificationsCache.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/NotificationsCache.java
@@ -1,0 +1,48 @@
+package com.salesforce.dva.argus.service.alert;
+
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+public class NotificationsCache {
+	
+	private NotificationsCacheRefresherThread refresherThread;
+
+	private Map<BigInteger/*notificationId*/, Map<String/*metricKey*/, Long/*coolDownExpiration*/>> notificationCooldownExpirationMap = new HashMap<BigInteger, Map<String, Long>>();
+
+	private Map<BigInteger/*notificationId*/, Map<String/*metricKey*/, Boolean/*activeStatus*/>> notificationActiveStatusMap = new HashMap<BigInteger, Map<String, Boolean>>();
+
+	private boolean isNotificationsCacheRefreshed = false;
+	
+	public NotificationsCache(EntityManager em) {
+		refresherThread = new NotificationsCacheRefresherThread(this, em);
+		refresherThread.setDaemon(true);
+		refresherThread.start();
+	}
+
+	public Map<BigInteger, Map<String, Long>> getNotificationCooldownExpirationMap() {
+		return notificationCooldownExpirationMap;
+	}
+
+	public void setNotificationCooldownExpirationMap(Map<BigInteger, Map<String, Long>> notificationCooldownExpirationMap) {
+		this.notificationCooldownExpirationMap = notificationCooldownExpirationMap;
+	}
+
+	public Map<BigInteger, Map<String, Boolean>> getNotificationActiveStatusMap() {
+		return notificationActiveStatusMap;
+	}
+
+	public void setNotificationActiveStatusMap(Map<BigInteger, Map<String, Boolean>> notificationActiveStatusMap) {
+		this.notificationActiveStatusMap = notificationActiveStatusMap;
+	}
+	
+	public boolean isNotificationsCacheRefreshed() {
+		return isNotificationsCacheRefreshed;
+	}
+
+	public void setNotificationsCacheRefreshed(boolean isNotificationsCacheRefreshed) {
+		this.isNotificationsCacheRefreshed = isNotificationsCacheRefreshed;
+	}
+}

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/NotificationsCacheRefresherThread.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/NotificationsCacheRefresherThread.java
@@ -1,0 +1,81 @@
+package com.salesforce.dva.argus.service.alert;
+
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NotificationsCacheRefresherThread extends Thread{
+
+	private final Logger _logger = LoggerFactory.getLogger(NotificationsCacheRefresherThread.class);
+	
+	private static final Long SLEEP_INTERVAL_MILLIS = 60*1000L;
+	
+	private NotificationsCache notificationsCache = null;
+	
+	private EntityManager _em;
+	
+	public NotificationsCacheRefresherThread(NotificationsCache cache, EntityManager em) {
+        this.notificationsCache = cache;
+        this._em = em;
+	}
+
+	@Override
+	public void run() {
+		_logger.info("Notifications cache fetcher thread started");
+		while (!isInterrupted()) {
+			try {
+				// populating notifications cooldown cache
+				Query q = _em.createNativeQuery("select * from notification_cooldownexpirationbytriggerandmetric");
+				List<Object[]> objects = q.getResultList();
+
+				Map<BigInteger/*notificationId*/, Map<String/*metricKey*/, Long/*coolDownExpiration*/>> currNotificationCooldownExpirationMap = new HashMap<BigInteger, Map<String, Long>>();
+
+				for(Object[] object : objects) {
+					BigInteger notificationId = new BigInteger(String.valueOf(Long.class.cast(object[0])));
+					Long cooldownExpiration = Long.class.cast(object[1]);
+					String key = String.class.cast(object[2]);
+					if(currNotificationCooldownExpirationMap.get(notificationId)==null) {
+						currNotificationCooldownExpirationMap.put(notificationId, new HashMap<String, Long>());
+					}
+					currNotificationCooldownExpirationMap.get(notificationId).put(key, cooldownExpiration);
+				}
+				
+				notificationsCache.setNotificationCooldownExpirationMap(currNotificationCooldownExpirationMap);
+
+				q = _em.createNativeQuery("select * from notification_activestatusbytriggerandmetric");
+				objects = q.getResultList();
+				Map<BigInteger/*notificationId*/, Map<String/*metricKey*/, Boolean/*activeStatus*/>> currNotificationActiveStatusMap = new HashMap<BigInteger, Map<String, Boolean>>();
+
+				for(Object[] object : objects) {
+					BigInteger notificationId = new BigInteger(String.valueOf(Long.class.cast(object[0])));
+					Boolean isActive;
+					try {
+						isActive = Boolean.class.cast(object[1]);
+					} catch (ClassCastException e) {
+						// This is because Embedded Derby stores booleans as 0, 1.
+						isActive = Integer.class.cast(object[1]) == 0 ? Boolean.FALSE : Boolean.TRUE;
+					}
+					String key = String.class.cast(object[2]);
+					if(currNotificationActiveStatusMap.get(notificationId)==null) {
+						currNotificationActiveStatusMap.put(notificationId, new HashMap<String, Boolean>());
+					}
+					currNotificationActiveStatusMap.get(notificationId).put(key, isActive);
+				}
+				notificationsCache.setNotificationActiveStatusMap(currNotificationActiveStatusMap);
+				notificationsCache.setNotificationsCacheRefreshed(true);
+				sleep(SLEEP_INTERVAL_MILLIS);
+			}catch(Exception e) {
+				_logger.error("Exception occured when trying to refresh notifications cache - " + ExceptionUtils.getFullStackTrace(e));
+				notificationsCache.setNotificationsCacheRefreshed(false);
+			}
+		}
+	}
+}

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/NotificationsCacheRefresherThread.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/NotificationsCacheRefresherThread.java
@@ -33,8 +33,9 @@ public class NotificationsCacheRefresherThread extends Thread{
 	public void run() {
 		while (!isInterrupted()) {
 			try {
+				sleep(SLEEP_INTERVAL_MILLIS);
 				_logger.info("Starting notifications cache refresh");
-				
+	
 				EntityManager em = _emProvider.get();
 				// populating notifications cooldown cache
 				Query q = em.createNativeQuery("select * from notification_cooldownexpirationbytriggerandmetric");
@@ -76,8 +77,7 @@ public class NotificationsCacheRefresherThread extends Thread{
 				notificationsCache.setNotificationActiveStatusMap(currNotificationActiveStatusMap);
 				
 				notificationsCache.setNotificationsCacheRefreshed(true);
-				_logger.info("Notifications cache refresh successful. Sleeping before refreshing again");
-				sleep(SLEEP_INTERVAL_MILLIS);
+				_logger.info("Notifications cache refresh successful.");
 			}catch(Exception e) {
 				_logger.error("Exception occured when trying to refresh notifications cache - " + ExceptionUtils.getFullStackTrace(e));
 				notificationsCache.setNotificationsCacheRefreshed(false);

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/audit/HBaseAuditService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/audit/HBaseAuditService.java
@@ -103,7 +103,7 @@ public class HBaseAuditService extends DefaultService implements AuditService {
 			deferred.addCallback(new Callback<Object, Object>() {
 				@Override
 				public Object call(Object arg) throws Exception {
-					_logger.trace(MessageFormat.format("Put to {0} successful.", tablename));
+					_logger.debug(MessageFormat.format("Put to {0} successful.", tablename));
 					return null;
 				}
 			});


### PR DESCRIPTION
Mirror of salesforce argus#744
Made changes to fetch the latest notifications status and store them in a local cache on each of the alert clients. This cache will be periodically refreshed every minute. With this change, there will be very minimal amount of queries made to postgres database during alert evaluation
